### PR TITLE
fix for webhook action selector, disregard casing when comparing verb

### DIFF
--- a/src/OrderCloud.AzureApp/WebhookActionSelector.cs
+++ b/src/OrderCloud.AzureApp/WebhookActionSelector.cs
@@ -52,7 +52,7 @@ namespace OrderCloud.AzureApp
 				return false; // none of our ambiguous candidates are specific webhook handlers
 
 			if (ReadWebhookPayload(context, out var verb, out var route)) {
-				var matchingHandlers = webhookHandlers.Where(h => h.SentOn.Verb == verb && h.SentOn.Route == route).ToList();
+			    var matchingHandlers = webhookHandlers.Where(h => h.SentOn.Verb.Equals(verb, StringComparison.CurrentCultureIgnoreCase) && h.SentOn.Route == route).ToList();
 				if (matchingHandlers.Count == 1) {
 					// found exactly 1 matching webhook handler. woo!
 					result = matchingHandlers[0].Action;


### PR DESCRIPTION
most of the time the verb in the request is uppercase so comparison works fine but i ran into a scenario for the order patch webhook where the verb was lowercase so it didn't select the correct action